### PR TITLE
Bash client: fix bug for files specified with path

### DIFF
--- a/clients/Bash/upload2section.sh
+++ b/clients/Bash/upload2section.sh
@@ -12,22 +12,23 @@ fi
 # Assign command-line parameters to named variables
 course=$1
 section=$2
-filename=$3
+filepath=$3
+filename=${filepath##*/}    # Strip directories from path
 displayname=${4:-$filename} # Use filename if display name not specified
 
 # Read Moodle configuration, including secret tokens
 source moodle.config
 
 # Upload the file
-upload_output=$(curl -sS -F "file_1=@${filename}" "https://${moodle_host}/webservice/upload.php?token=${moodle_web_service_token}")
+upload_output=$(curl -sS -F "file_1=@${filepath}" "https://${moodle_host}/webservice/upload.php?token=${moodle_web_service_token}")
 
 # Get uploaded file ID from cURL output
 item_pattern='"itemid":([0-9]+)'
 if [[ "${upload_output}" =~ $item_pattern ]]; then
   uploaded_item=${BASH_REMATCH[1]}
-  echo "Uploaded \"${filename}\" to item ${uploaded_item}"
+  echo "Uploaded \"${filepath}\" to item ${uploaded_item}"
 else
-  echo "Unexpected output for upload of file \"${filename}\": ${upload_output}" >&2
+  echo "Unexpected output for upload of file \"${filepath}\": ${upload_output}" >&2
   exit 1
 fi
 


### PR DESCRIPTION
This fixes a bug when the script is given a file with path (e.g. `/a/b/file`) instead of just a file name.

Before this fix, the script would output an error message such as the following:

```
Uploaded "/a/b/file" to item XXX
File placed in private area
Unexpected output when adding file to course's section: <?xml version="1.0" encoding="UTF-8" ?>
<EXCEPTION class="moodle_exception">
<ERRORCODE>filenotfound</ERRORCODE>
<MESSAGE>Le fichier demandé n'a pas été trouvé</MESSAGE>
</EXCEPTION>
```